### PR TITLE
Use relative paths when running -l / --relative

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -15,7 +15,7 @@ import { createIndexPage } from "./transformations/html/createIndexPage";
 
 export class Project {
   projectDirectory: string;
-  relativePath: string;
+  useRelativePaths: boolean;
   configPath: string;
   outPath: string;
   versionPath: string;
@@ -29,9 +29,9 @@ export class Project {
     return purge((this.modules || []).map(m => m.errors));
   }
 
-  constructor(projectDirectory: string, relativePath: string = ".", isRelease: boolean = false) {
+  constructor(projectDirectory: string, useRelativePaths: boolean = false, isRelease: boolean = false) {
     this.projectDirectory = projectDirectory;
-    this.relativePath = relativePath;
+    this.useRelativePaths = useRelativePaths;
     this.configPath = join(this.projectDirectory, "carconfig.json");
     this.preludePath = join(this.projectDirectory, "Prelude.car");
     this.outPath = join(this.projectDirectory, ".out");
@@ -152,7 +152,7 @@ export class Project {
 
   async writeIndexFile(): Promise<Project> {
     return new Promise((resolve, reject) => {
-      let source = createIndexPage(this.modules, this.isRelease);
+      let source = createIndexPage(this.modules, this.isRelease, this.useRelativePaths);
       outputFile(join(this.versionPath, "index.html"), source);
       resolve(this);
     });

--- a/src/ckc.ts
+++ b/src/ckc.ts
@@ -92,17 +92,17 @@ program
     try {
       let {
         path = ".",
-        relative = false
+        relative: useRelativePaths = false,
         // ts = false,
         // xsd = false,
         // all = false,
         // module
       } = args.reverse()[0];
-      if (relative) {
+      if (useRelativePaths) {
         console.log("Compiling a relative version.");
       }
       let fullPath = resolve(path);
-      let project = await new Project(fullPath, path, relative).compile();
+      let project = await new Project(fullPath, path, useRelativePaths).compile();
     } catch (err) {
       console.log(err);
     }

--- a/src/transformations/html/createIndexPage.ts
+++ b/src/transformations/html/createIndexPage.ts
@@ -1,11 +1,15 @@
 import { IModule } from "./../../helpers";
 
-export const createIndexPage = (modules: IModule[], isRelease: boolean) => {
+export const createIndexPage = (modules: IModule[], isRelease: boolean, useRelativePaths: boolean) => {
   let moduleList = modules
     .map(m => {
+      if(useRelativePaths) {
+        return `<li><a href="${m.name + `/` +m.name}.html">${m.name}</a></li>`;
+      } else {
       return isRelease
         ? `<li><a href="/public/${m.name}.html">${m.name}</a></li>`
         : `<li><a href="${m.htmlPath.replace(m.projectDirectory, "")}">${m.name}</a></li>`;
+      }
     })
     .join("\n");
 


### PR DESCRIPTION
- Sent useRelativePaths from ckc to project to createIndex page (where the paths originally went wrong)
- Determine path in createIndexPage based on relative or not

@Baudin999 is this path (name / name) correct, or will this cause issues in certain cases?
The fallback would be to remove /output/{version} from the original url
